### PR TITLE
Delete lb security groups

### DIFF
--- a/cloud-controller-manager/osc/ccm_cloud.go
+++ b/cloud-controller-manager/osc/ccm_cloud.go
@@ -1632,6 +1632,10 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 	securityGroupsItem := []string{}
 	if len(lb.SecurityGroups) == 0 && c.vpcID == "" {
 		securityGroupsItem = append(securityGroupsItem, DefaultSrcSgName)
+	} else if len(lb.SecurityGroups) > 0 {
+		for _, securityGroup := range lb.SecurityGroups {
+			securityGroupsItem = append(securityGroupsItem, *securityGroup)
+		}
 	}
 
 	{


### PR DESCRIPTION
When LB is deleted, underlying security group (with name like ```k8s-elb-<LB_NAME>```) is not.