### PR TITLE
Update GH Action to test the real code

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,7 +12,11 @@ jobs:
   create_cluster:
     runs-on: [self-hosted, linux]
     steps:
+    # Retrieve the code from the repo (UNSAFE)
     - uses: actions/checkout@v2
+      with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
     - uses: actions/checkout@v2
       with:
         repository: 'outscale-dev/osc-k8s-rke-cluster'


### PR DESCRIPTION
Until now, the e2e tested the target branch (the branch that we want to push). This was not what we wanted to do.

With this fix, we DO test the code but we need to take care of credential leaking. We need to set up the repo to enforce approval of exzcution of GH Action from people outside of the organization (cf [doc](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)) 