### PR TITLE
Use Filter instead of InstanceId to describe instances

### DIFF
--- a/cloud-controller-manager/osc/ccm_cloud.go
+++ b/cloud-controller-manager/osc/ccm_cloud.go
@@ -299,7 +299,9 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 	}
 
 	request := &ec2.DescribeInstancesInput{
-		InstanceIds: []*string{instanceID.awsString()},
+		Filters: []*ec2.Filter{
+			newEc2Filter("instance-id", string(instanceID)),
+		},
 	}
 
 	instances, err := c.ec2.DescribeInstances(request)

--- a/cloud-controller-manager/osc/instances_v2.go
+++ b/cloud-controller-manager/osc/instances_v2.go
@@ -146,7 +146,9 @@ func (i *instancesV2) getInstance(ctx context.Context, node *v1.Node) (*ec2.Inst
 		}
 
 		request = &ec2.DescribeInstancesInput{
-			InstanceIds: []*string{aws.String(instanceID)},
+			Filters: []*ec2.Filter{
+				newEc2Filter("instance-id", instanceID),
+			},
 		}
 		klog.V(4).Infof("looking for node by provider ID %v", node.Spec.ProviderID)
 	}
@@ -155,7 +157,7 @@ func (i *instancesV2) getInstance(ctx context.Context, node *v1.Node) (*ec2.Inst
 	var nextToken *string
 	for {
 		response, err := i.ec2.DescribeInstances(request)
-		klog.V(4).Infof("looking for node by private DNS name %v", response)
+		klog.V(4).Infof("Get Response from Describe Instances  %v", response)
 
 		if err != nil {
 			return nil, fmt.Errorf("error describing ec2 instances: %v", err)


### PR DESCRIPTION
This is useful if the instance does not exist anymore because the SDK
will not throw an error but will answer with empty result

Closes #83 
