### PR TITLE
Fix build Ci

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# github.com/emicklei/go-restful 
+CVE-2022-1996

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,10 @@ trivy-scan:
 	docker pull $(TRIVY_IMAGE)
 	docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
+			-v ${PWD}/.trivyignore:/root/.trivyignore \
 			$(TRIVY_IMAGE) \
 			image \
 			--exit-code 1 \
 			--severity="HIGH,CRITICAL" \
+			--ignorefile /root/.trivyignore \
 			$(IMAGE):$(IMAGE_VERSION)


### PR DESCRIPTION
Ignore the CVE-2022-1996
- go-restfull is used by apiserver and the fixed version was updated at
  this commit
(https://github.com/kubernetes/apiserver/commit/53cb6f3f984998b2cab6b8afbeec394218ab76e6)
which is plan to be relase at the same time as Kubernetes 1.25.0
