### PR TITLE
Add Code Scanning tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,12 @@ on:
       - "go.*"
       - ".github/workflows/build.yml"
       - "!tests/**"
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    
 jobs:
   Build:
-    if: github.repository == 'outscale-dev/cloud-provider-osc'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -38,4 +41,10 @@ jobs:
     - name: Image
       run: bash -c "make build-image"
     - name: Trivy-Scan
+      id: trivyscan
       run: bash -c "make trivy-scan"
+    - name: Upload Scan if errors
+      if: ${{ failure() && github.event_name != 'pull_request' && steps.trivyscan.outcome == 'failure' }}
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: './.trivyscan/report.sarif'

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ E2E_ENV := "build-e2e-cloud-provider"
 E2E_AZ := "eu-west-2a"
 E2E_REGION := "eu-west-2"
 
-TRIVY_IMAGE := aquasec/trivy:0.19.2
+TRIVY_IMAGE := aquasec/trivy:0.30.0
 
 .PHONY: help
 help:
@@ -110,9 +110,12 @@ trivy-scan:
 	docker run --rm \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v ${PWD}/.trivyignore:/root/.trivyignore \
+			-v ${PWD}/.trivyscan/:/root/.trivyscan \
 			$(TRIVY_IMAGE) \
 			image \
 			--exit-code 1 \
 			--severity="HIGH,CRITICAL" \
 			--ignorefile /root/.trivyignore \
+			--security-checks vuln \
+			--format sarif -o /root/.trivyscan/report.sarif \
 			$(IMAGE):$(IMAGE_VERSION)


### PR DESCRIPTION
This will run trivy-scan daily and report CVE in Github security tabs

(See https://github.com/outscale-mdr/cloud-provider-osc/security/code-scanning for example)