### PR TITLE
Adapt Log verbosity

### DIFF
--- a/cloud-controller-manager/osc/ccm.go
+++ b/cloud-controller-manager/osc/ccm.go
@@ -32,7 +32,7 @@ import (
 
 func readCloudConfig(config io.Reader) (*CloudConfig, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("readAWSCloudConfig(%v)", config)
+	klog.V(5).Infof("readAWSCloudConfig(%v)", config)
 	var cfg CloudConfig
 	var err error
 
@@ -48,7 +48,7 @@ func readCloudConfig(config io.Reader) (*CloudConfig, error) {
 
 func newCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("newAWSCloud(%v, %v)", cfg, awsServices)
+	klog.V(5).Infof("newAWSCloud(%v, %v)", cfg, awsServices)
 	// We have some state in the Cloud object - in particular the attaching map
 	// Log so that if we are building multiple Cloud objects, it is obvious!
 	klog.Infof("Starting OSC cloud provider")
@@ -152,7 +152,7 @@ func newCloud(cfg CloudConfig, awsServices Services) (*Cloud, error) {
 
 func init() {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("init()")
+	klog.V(5).Infof("init()")
 	registerMetrics()
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := readCloudConfig(config)

--- a/cloud-controller-manager/osc/ccm_cloud.go
+++ b/cloud-controller-manager/osc/ccm_cloud.go
@@ -84,7 +84,7 @@ type Cloud struct {
 // This is called when the AWSCloud is initialized, and should not be called otherwise (because the awsInstance for the local instance is a singleton with drive mapping state)
 func (c *Cloud) buildSelfAWSInstance() (*VM, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("buildSelfAWSInstance()")
+	klog.V(5).Infof("buildSelfAWSInstance()")
 	if c.selfAWSInstance != nil {
 		panic("do not call buildSelfAWSInstance directly")
 	}
@@ -112,7 +112,7 @@ func (c *Cloud) buildSelfAWSInstance() (*VM, error) {
 // leverage Kubernetes API for caching
 func (c *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("SetInformers(%v)", informerFactory)
+	klog.V(5).Infof("SetInformers(%v)", informerFactory)
 	klog.Infof("Setting up informers for Cloud")
 	c.nodeInformer = informerFactory.Core().V1().Nodes()
 	c.nodeInformerHasSynced = c.nodeInformer.Informer().HasSynced
@@ -121,14 +121,14 @@ func (c *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 // AddSSHKeyToAllInstances is currently not implemented.
 func (c *Cloud) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("AddSSHKeyToAllInstances(%v,%v)", user, keyData)
+	klog.V(5).Infof("AddSSHKeyToAllInstances(%v,%v)", user, keyData)
 	return cloudprovider.NotImplemented
 }
 
 // CurrentNodeName returns the name of the current node
 func (c *Cloud) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("CurrentNodeName(%v)", hostname)
+	klog.V(5).Infof("CurrentNodeName(%v)", hostname)
 	return c.selfAWSInstance.nodeName, nil
 }
 
@@ -136,7 +136,7 @@ func (c *Cloud) CurrentNodeName(ctx context.Context, hostname string) (types.Nod
 func (c *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 	stop <-chan struct{}) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("Initialize(%v,%v)", clientBuilder, stop)
+	klog.V(5).Infof("Initialize(%v,%v)", clientBuilder, stop)
 	c.clientBuilder = clientBuilder
 	c.kubeClient = clientBuilder.ClientOrDie("aws-cloud-provider")
 	c.eventBroadcaster = record.NewBroadcaster()
@@ -148,28 +148,28 @@ func (c *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
 // Clusters returns the list of clusters.
 func (c *Cloud) Clusters() (cloudprovider.Clusters, bool) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("Clusters()")
+	klog.V(5).Infof("Clusters()")
 	return nil, false
 }
 
 // ProviderName returns the cloud provider ID.
 func (c *Cloud) ProviderName() string {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("ProviderName")
+	klog.V(5).Infof("ProviderName")
 	return ProviderName
 }
 
 // LoadBalancer returns an implementation of LoadBalancer for Amazon Web Services.
 func (c *Cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("LoadBalancer()")
+	klog.V(5).Infof("LoadBalancer()")
 	return c, true
 }
 
 // Instances returns an implementation of Instances for Amazon Web Services.
 func (c *Cloud) Instances() (cloudprovider.Instances, bool) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("Instances()")
+	klog.V(5).Infof("Instances()")
 	return c, true
 }
 
@@ -202,7 +202,7 @@ func (c *Cloud) HasClusterID() bool {
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.NodeAddress, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("NodeAddresses(%v)", name)
+	klog.V(5).Infof("NodeAddresses(%v)", name)
 	if c.selfAWSInstance.nodeName == name || len(name) == 0 {
 		addresses := []v1.NodeAddress{}
 
@@ -274,7 +274,7 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
 // and other local methods cannot be used here
 func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("NodeAddressesByProviderID(%v)", providerID)
+	klog.V(5).Infof("NodeAddressesByProviderID(%v)", providerID)
 	instanceID, err := KubernetesInstanceID(providerID).MapToAWSInstanceID()
 	if err != nil {
 		return nil, err
@@ -292,7 +292,7 @@ func (c *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("InstanceExistsByProviderID(%v)", providerID)
+	klog.V(5).Infof("InstanceExistsByProviderID(%v)", providerID)
 	instanceID, err := KubernetesInstanceID(providerID).MapToAWSInstanceID()
 	if err != nil {
 		return false, err
@@ -327,7 +327,7 @@ func (c *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID strin
 // InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
 func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("InstanceShutdownByProviderID(%v)", providerID)
+	klog.V(5).Infof("InstanceShutdownByProviderID(%v)", providerID)
 	instanceID, err := KubernetesInstanceID(providerID).MapToAWSInstanceID()
 	if err != nil {
 		return false, err
@@ -366,7 +366,7 @@ func (c *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID str
 // InstanceID returns the cloud provider ID of the node with the specified nodeName.
 func (c *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("InstanceID(%v)", nodeName)
+	klog.V(5).Infof("InstanceID(%v)", nodeName)
 	// In the future it is possible to also return an endpoint as:
 	// <endpoint>/<zone>/<instanceid>
 	if c.selfAWSInstance.nodeName == nodeName {
@@ -388,7 +388,7 @@ func (c *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string
 // and other local methods cannot be used here
 func (c *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("InstanceTypeByProviderID(%v)", providerID)
+	klog.V(5).Infof("InstanceTypeByProviderID(%v)", providerID)
 	instanceID, err := KubernetesInstanceID(providerID).MapToAWSInstanceID()
 	if err != nil {
 		return "", err
@@ -405,7 +405,7 @@ func (c *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string)
 // InstanceType returns the type of the node with the specified nodeName.
 func (c *Cloud) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("InstanceType(%v)", nodeName)
+	klog.V(5).Infof("InstanceType(%v)", nodeName)
 	if c.selfAWSInstance.nodeName == nodeName {
 		return c.selfAWSInstance.instanceType, nil
 	}
@@ -430,7 +430,7 @@ func (c *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 // does not initialize node data.
 func (c *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("GetZoneByProviderID(%v)", providerID)
+	klog.V(5).Infof("GetZoneByProviderID(%v)", providerID)
 	instanceID, err := KubernetesInstanceID(providerID).MapToAWSInstanceID()
 	if err != nil {
 		return cloudprovider.Zone{}, err
@@ -453,7 +453,7 @@ func (c *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (clo
 // does not initialize node data.
 func (c *Cloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("GetZoneByNodeName(%v)", nodeName)
+	klog.V(5).Infof("GetZoneByNodeName(%v)", nodeName)
 	instance, err := c.getInstanceByNodeName(nodeName)
 	if err != nil {
 		return cloudprovider.Zone{}, err
@@ -470,7 +470,7 @@ func (c *Cloud) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) 
 // Retrieves instance's vpc id from metadata
 func (c *Cloud) findVPCID() (string, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("findVPCID()")
+	klog.V(5).Infof("findVPCID()")
 	macs, err := c.metadata.GetMetadata("network/interfaces/macs/")
 	if err != nil {
 		return "", fmt.Errorf("could not list interfaces of the instance: %q", err)
@@ -495,7 +495,7 @@ func (c *Cloud) findVPCID() (string, error) {
 
 func (c *Cloud) addLoadBalancerTags(loadBalancerName string, requested map[string]string) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("addLoadBalancerTags(%v,%v)", loadBalancerName, requested)
+	klog.V(5).Infof("addLoadBalancerTags(%v,%v)", loadBalancerName, requested)
 	var tags []*elb.Tag
 	for k, v := range requested {
 		tag := &elb.Tag{
@@ -519,7 +519,7 @@ func (c *Cloud) addLoadBalancerTags(loadBalancerName string, requested map[strin
 // Gets the current load balancer state
 func (c *Cloud) describeLoadBalancer(name string) (*elb.LoadBalancerDescription, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("describeLoadBalancer(%v)", name)
+	klog.V(5).Infof("describeLoadBalancer(%v)", name)
 	request := &elb.DescribeLoadBalancersInput{}
 	request.LoadBalancerNames = []*string{&name}
 
@@ -546,7 +546,7 @@ func (c *Cloud) describeLoadBalancer(name string) (*elb.LoadBalancerDescription,
 // Retrieves the specified security group from the AWS API, or returns nil if not found
 func (c *Cloud) findSecurityGroup(securityGroupID string) (*osc.SecurityGroup, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("findSecurityGroup(%v)", securityGroupID)
+	klog.V(5).Infof("findSecurityGroup(%v)", securityGroupID)
 	readSecurityGroupsRequest := osc.ReadSecurityGroupsRequest{
 		Filters: &osc.FiltersSecurityGroup{
 			SecurityGroupIds: &[]string{
@@ -578,7 +578,7 @@ func (c *Cloud) findSecurityGroup(securityGroupID string) (*osc.SecurityGroup, e
 // The security group must already exist
 func (c *Cloud) setSecurityGroupIngress(securityGroupID string, permissions IPRulesSet) (bool, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("setSecurityGroupIngress(%v,%v)", securityGroupID, permissions)
+	klog.V(5).Infof("setSecurityGroupIngress(%v,%v)", securityGroupID, permissions)
 	// We do not want to make changes to the Global defined SG
 	if securityGroupID == c.cfg.Global.ElbSecurityGroup {
 		return false, nil
@@ -663,7 +663,7 @@ func (c *Cloud) setSecurityGroupIngress(securityGroupID string, permissions IPRu
 // The security group must already exist
 func (c *Cloud) addSecurityGroupRules(securityGroupID string, addPermissions *[]osc.SecurityGroupRule, isPublicCloud bool) (bool, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("addSecurityGroupRules(%v,%v,%v)", securityGroupID, addPermissions, isPublicCloud)
+	klog.V(5).Infof("addSecurityGroupRules(%v,%v,%v)", securityGroupID, addPermissions, isPublicCloud)
 	// We do not want to make changes to the Global defined SG
 	if securityGroupID == c.cfg.Global.ElbSecurityGroup {
 		return false, nil
@@ -743,7 +743,7 @@ func (c *Cloud) addSecurityGroupRules(securityGroupID string, addPermissions *[]
 // If the security group no longer exists, will return (false, nil)
 func (c *Cloud) removeSecurityGroupRules(securityGroupID string, removePermissions *[]osc.SecurityGroupRule, isPublicCloud bool) (bool, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("removeSecurityGroupRules(%v,%v)", securityGroupID, removePermissions)
+	klog.V(5).Infof("removeSecurityGroupRules(%v,%v)", securityGroupID, removePermissions)
 	// We do not want to make changes to the Global defined SG
 	if securityGroupID == c.cfg.Global.ElbSecurityGroup {
 		return false, nil
@@ -810,7 +810,7 @@ func (c *Cloud) removeSecurityGroupRules(securityGroupID string, removePermissio
 // Returns the security group id or error
 func (c *Cloud) ensureSecurityGroup(name string, description string, additionalTags map[string]string) (string, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("ensureSecurityGroup (%v,%v,%v)", name, description, additionalTags)
+	klog.V(5).Infof("ensureSecurityGroup (%v,%v,%v)", name, description, additionalTags)
 
 	groupID := ""
 	attempt := 0
@@ -895,7 +895,7 @@ func (c *Cloud) ensureSecurityGroup(name string, description string, additionalT
 // However, in future this will likely be treated as an error.
 func (c *Cloud) findSubnets() ([]*osc.Subnet, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("findSubnets()")
+	klog.V(5).Infof("findSubnets()")
 	request := osc.ReadSubnetsRequest{}
 	if c.vpcID != "" {
 		request.SetFilters(osc.FiltersSubnet{
@@ -954,7 +954,7 @@ func (c *Cloud) findSubnets() ([]*osc.Subnet, error) {
 // Internal ELBs can use public or private subnets, but if we have a private subnet we should prefer that.
 func (c *Cloud) findELBSubnets(internalELB bool) ([]string, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("findELBSubnets(%v)", internalELB)
+	klog.V(5).Infof("findELBSubnets(%v)", internalELB)
 
 	subnets, err := c.findSubnets()
 	if err != nil {
@@ -1054,7 +1054,7 @@ func (c *Cloud) findELBSubnets(internalELB bool) ([]string, error) {
 // setting the security groups specified.
 func (c *Cloud) buildELBSecurityGroupList(serviceName types.NamespacedName, loadBalancerName string, annotations map[string]string) ([]string, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("buildELBSecurityGroupList(%v,%v,%v)", serviceName, loadBalancerName, annotations)
+	klog.V(5).Infof("buildELBSecurityGroupList(%v,%v,%v)", serviceName, loadBalancerName, annotations)
 	var err error
 	var securityGroupID string
 
@@ -1099,8 +1099,8 @@ func (c *Cloud) buildELBSecurityGroupList(serviceName types.NamespacedName, load
 func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiService *v1.Service,
 	nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("EnsureLoadBalancer(%v, %v, %v)", clusterName, apiService, nodes)
-	klog.V(10).Infof("EnsureLoadBalancer.annotations(%v)", apiService.Annotations)
+	klog.V(5).Infof("EnsureLoadBalancer(%v, %v, %v)", clusterName, apiService, nodes)
+	klog.V(5).Infof("EnsureLoadBalancer.annotations(%v)", apiService.Annotations)
 	annotations := apiService.Annotations
 	if apiService.Spec.SessionAffinity != v1.ServiceAffinityNone {
 		// ELB supports sticky sessions, but only when configured for HTTP/HTTPS
@@ -1137,13 +1137,13 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 	}
 
 	instances, err := c.findInstancesForELB(nodes)
-	klog.V(10).Infof("Debug OSC: c.findInstancesForELB(nodes) : %v", instances)
+	klog.V(5).Infof("Debug OSC: c.findInstancesForELB(nodes) : %v", instances)
 	if err != nil {
 		return nil, err
 	}
 
 	sourceRanges, err := servicehelpers.GetLoadBalancerSourceRanges(apiService)
-	klog.V(10).Infof("Debug OSC:  servicehelpers.GetLoadBalancerSourceRanges : %v", sourceRanges)
+	klog.V(5).Infof("Debug OSC:  servicehelpers.GetLoadBalancerSourceRanges : %v", sourceRanges)
 	if err != nil {
 		return nil, err
 	}
@@ -1156,7 +1156,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 	} else if internalAnnotation != "" {
 		internalELB = true
 	}
-	klog.V(10).Infof("Debug OSC:  internalELB : %v", internalELB)
+	klog.V(5).Infof("Debug OSC:  internalELB : %v", internalELB)
 
 	// Determine if we need to set the Proxy protocol policy
 	proxyProtocol := false
@@ -1215,7 +1215,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		if accessLogS3BucketPrefixAnnotation != "" {
 			loadBalancerAttributes.AccessLog.S3BucketPrefix = &accessLogS3BucketPrefixAnnotation
 		}
-		klog.V(10).Infof("Debug OSC:  loadBalancerAttributes.AccessLog : %v", loadBalancerAttributes.AccessLog)
+		klog.V(5).Infof("Debug OSC:  loadBalancerAttributes.AccessLog : %v", loadBalancerAttributes.AccessLog)
 	}
 
 	// Determine if connection draining enabled/disabled has been specified
@@ -1274,9 +1274,9 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, apiService)
 	serviceName := types.NamespacedName{Namespace: apiService.Namespace, Name: apiService.Name}
 
-	klog.V(10).Infof("Debug OSC:  loadBalancerName : %v", loadBalancerName)
-	klog.V(10).Infof("Debug OSC:  serviceName : %v", serviceName)
-	klog.V(10).Infof("Debug OSC:  serviceName : %v", annotations)
+	klog.V(5).Infof("Debug OSC:  loadBalancerName : %v", loadBalancerName)
+	klog.V(5).Infof("Debug OSC:  serviceName : %v", serviceName)
+	klog.V(5).Infof("Debug OSC:  serviceName : %v", annotations)
 
 	var securityGroupIDs []string
 
@@ -1286,7 +1286,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 		securityGroupIDs, err = c.buildELBSecurityGroupList(serviceName, loadBalancerName, annotations)
 	}
 
-	klog.V(10).Infof("Debug OSC:  ensured securityGroupIDs : %v", securityGroupIDs)
+	klog.V(5).Infof("Debug OSC:  ensured securityGroupIDs : %v", securityGroupIDs)
 
 	if err != nil {
 		return nil, err
@@ -1418,7 +1418,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
 // GetLoadBalancer is an implementation of LoadBalancer.GetLoadBalancer
 func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("GetLoadBalancer(%v,%v)", clusterName, service)
+	klog.V(5).Infof("GetLoadBalancer(%v,%v)", clusterName, service)
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
 	lb, err := c.describeLoadBalancer(loadBalancerName)
@@ -1437,7 +1437,7 @@ func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service
 // GetLoadBalancerName is an implementation of LoadBalancer.GetLoadBalancerName
 func (c *Cloud) GetLoadBalancerName(ctx context.Context, clusterName string, service *v1.Service) string {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("GetLoadBalancerName(%v,%v)", clusterName, service)
+	klog.V(5).Infof("GetLoadBalancerName(%v,%v)", clusterName, service)
 
 	//The unique name of the load balancer (32 alphanumeric or hyphen characters maximum, but cannot start or end with a hyphen).
 	ret := strings.Replace(string(service.UID), "-", "", -1)
@@ -1470,7 +1470,7 @@ func (c *Cloud) GetLoadBalancerName(ctx context.Context, clusterName string, ser
 // Return all the security groups that are tagged as being part of our cluster
 func (c *Cloud) getTaggedSecurityGroups() (map[string]osc.SecurityGroup, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getTaggedSecurityGroups()")
+	klog.V(5).Infof("getTaggedSecurityGroups()")
 	request := osc.ReadSecurityGroupsRequest{
 		Filters: &osc.FiltersSecurityGroup{
 			TagKeys: &[]string{c.tagging.clusterTagKey()},
@@ -1505,7 +1505,7 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancer
 	instances map[InstanceID]*osc.Vm,
 	securityGroupIDs []string) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("updateInstanceSecurityGroupsForLoadBalancer(%v, %v, %v)", lb, instances, securityGroupIDs)
+	klog.V(5).Infof("updateInstanceSecurityGroupsForLoadBalancer(%v, %v, %v)", lb, instances, securityGroupIDs)
 
 	if c.cfg.Global.DisableSecurityGroupIngress {
 		return nil
@@ -1537,7 +1537,7 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancer
 		return fmt.Errorf("could not determine security group for load balancer: %s", aws.StringValue(lb.LoadBalancerName))
 	}
 
-	klog.V(10).Infof("loadBalancerSecurityGroupID(%v)", loadBalancerSecurityGroupID)
+	klog.V(5).Infof("loadBalancerSecurityGroupID(%v)", loadBalancerSecurityGroupID)
 
 	// Get the actual list of groups that allow ingress from the load-balancer
 	var actualGroups []osc.SecurityGroup
@@ -1563,13 +1563,13 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancer
 		}
 	}
 
-	klog.V(10).Infof("actualGroups(%v)", actualGroups)
+	klog.V(5).Infof("actualGroups(%v)", actualGroups)
 
 	taggedSecurityGroups, err := c.getTaggedSecurityGroups()
 	if err != nil {
 		return fmt.Errorf("error querying for tagged security groups: %q", err)
 	}
-	klog.V(10).Infof("taggedSecurityGroups(%v)", taggedSecurityGroups)
+	klog.V(5).Infof("taggedSecurityGroups(%v)", taggedSecurityGroups)
 
 	// Open the firewall from the load balancer to the instance
 	// We don't actually have a trivial way to know in advance which security group the instance is in
@@ -1599,7 +1599,7 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancer
 		instanceSecurityGroupIds[id] = true
 	}
 
-	klog.V(10).Infof("instanceSecurityGroupIds(%v)", instanceSecurityGroupIds)
+	klog.V(5).Infof("instanceSecurityGroupIds(%v)", instanceSecurityGroupIds)
 
 	// Compare to actual groups
 	for _, actualGroup := range actualGroups {
@@ -1619,7 +1619,7 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancer
 		}
 	}
 
-	klog.V(10).Infof("instanceSecurityGroupIds(%v)", instanceSecurityGroupIds)
+	klog.V(5).Infof("instanceSecurityGroupIds(%v)", instanceSecurityGroupIds)
 	for instanceSecurityGroupID, add := range instanceSecurityGroupIds {
 		if add {
 			klog.V(2).Infof("Adding rule for traffic from the load balancer (%s) to instances (%s)", loadBalancerSecurityGroupID, instanceSecurityGroupID)
@@ -1672,7 +1672,7 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancer
 // EnsureLoadBalancerDeleted implements LoadBalancer.EnsureLoadBalancerDeleted.
 func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("EnsureLoadBalancerDeleted(%v, %v)", clusterName, service)
+	klog.V(5).Infof("EnsureLoadBalancerDeleted(%v, %v)", clusterName, service)
 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
 
 	lb, err := c.describeLoadBalancer(loadBalancerName)
@@ -1811,7 +1811,7 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
 // UpdateLoadBalancer implements LoadBalancer.UpdateLoadBalancer
 func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("UpdateLoadBalancer(%v, %v, %s)", clusterName, service, nodes)
+	klog.V(5).Infof("UpdateLoadBalancer(%v, %v, %s)", clusterName, service, nodes)
 	instances, err := c.findInstancesForELB(nodes)
 	if err != nil {
 		return err
@@ -1863,7 +1863,7 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
 // Returns the instance with the specified ID
 func (c *Cloud) getInstanceByID(instanceID string) (*osc.Vm, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getInstanceByID(%v)", instanceID)
+	klog.V(5).Infof("getInstanceByID(%v)", instanceID)
 	instances, err := c.getInstancesByIDs(&[]string{instanceID})
 	if err != nil {
 		return nil, err
@@ -1881,7 +1881,7 @@ func (c *Cloud) getInstanceByID(instanceID string) (*osc.Vm, error) {
 
 func (c *Cloud) getInstancesByIDs(instanceIDs *[]string) (map[string]*osc.Vm, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getInstancesByIDs(%v)", instanceIDs)
+	klog.V(5).Infof("getInstancesByIDs(%v)", instanceIDs)
 
 	instancesByID := make(map[string]*osc.Vm)
 	if instanceIDs == nil || len(*instanceIDs) == 0 {
@@ -1914,7 +1914,7 @@ func (c *Cloud) getInstancesByIDs(instanceIDs *[]string) (map[string]*osc.Vm, er
 
 func (c *Cloud) getInstancesByNodeNames(nodeNames []string, states ...string) ([]*osc.Vm, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getInstancesByNodeNames(%v, %v)", nodeNames, states)
+	klog.V(5).Infof("getInstancesByNodeNames(%v, %v)", nodeNames, states)
 
 	names := nodeNames
 	oscInstances := []*osc.Vm{}
@@ -1944,7 +1944,7 @@ func (c *Cloud) getInstancesByNodeNames(nodeNames []string, states ...string) ([
 // TODO: Move to instanceCache
 func (c *Cloud) describeInstances(filters *osc.FiltersVm) ([]*osc.Vm, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("describeInstances(%v)", filters)
+	klog.V(5).Infof("describeInstances(%v)", filters)
 
 	request := &osc.ReadVmsRequest{
 		Filters: filters,
@@ -1969,7 +1969,7 @@ func (c *Cloud) describeInstances(filters *osc.FiltersVm) ([]*osc.Vm, error) {
 // Returns nil if it does not exist
 func (c *Cloud) findInstanceByNodeName(nodeName types.NodeName) (*osc.Vm, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("findInstanceByNodeName(%v)", nodeName)
+	klog.V(5).Infof("findInstanceByNodeName(%v)", nodeName)
 
 	privateDNSName := mapNodeNameToPrivateDNSName(nodeName)
 	filters := osc.FiltersVm{
@@ -2006,7 +2006,7 @@ func (c *Cloud) findInstanceByNodeName(nodeName types.NodeName) (*osc.Vm, error)
 // Like findInstanceByNodeName, but returns error if node not found
 func (c *Cloud) getInstanceByNodeName(nodeName types.NodeName) (*osc.Vm, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getInstanceByNodeName(%v)", nodeName)
+	klog.V(5).Infof("getInstanceByNodeName(%v)", nodeName)
 
 	var instance *osc.Vm
 
@@ -2030,7 +2030,7 @@ func (c *Cloud) getInstanceByNodeName(nodeName types.NodeName) (*osc.Vm, error) 
 
 func (c *Cloud) nodeNameToProviderID(nodeName types.NodeName) (InstanceID, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("nodeNameToProviderID(%v)", nodeName)
+	klog.V(5).Infof("nodeNameToProviderID(%v)", nodeName)
 	if len(nodeName) == 0 {
 		return "", fmt.Errorf("no nodeName provided")
 	}

--- a/cloud-controller-manager/osc/instances.go
+++ b/cloud-controller-manager/osc/instances.go
@@ -52,7 +52,7 @@ type KubernetesInstanceID string
 // MapToAWSInstanceID extracts the InstanceID from the KubernetesInstanceID
 func (name KubernetesInstanceID) MapToAWSInstanceID() (InstanceID, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("MapToAWSInstanceID(%v)", name)
+	klog.V(5).Infof("MapToAWSInstanceID(%v)", name)
 
 	s := string(name)
 

--- a/cloud-controller-manager/osc/log_handler.go
+++ b/cloud-controller-manager/osc/log_handler.go
@@ -27,17 +27,17 @@ import (
 // Handler for aws-sdk-go that logs all requests
 func awsHandlerLogger(req *request.Request) {
 	service, name := awsServiceAndName(req)
-	klog.V(4).Infof("AWS request: %s %s", service, name)
+	klog.V(2).Infof("AWS request: %s %s", service, name)
 }
 
 func awsSendHandlerLogger(req *request.Request) {
 	service, name := awsServiceAndName(req)
-	klog.V(4).Infof("AWS API Send: %s %s %v %v", service, name, req.Operation, req.Params)
+	klog.V(2).Infof("AWS API Send: %s %s %v %v", service, name, req.Operation, req.Params)
 }
 
 func awsValidateResponseHandlerLogger(req *request.Request) {
 	service, name := awsServiceAndName(req)
-	klog.V(4).Infof("AWS API ValidateResponse: %s %s %v %v %s", service, name, req.Operation, req.Params, req.HTTPResponse.Status)
+	klog.V(2).Infof("AWS API ValidateResponse: %s %s %v %v %s", service, name, req.Operation, req.Params, req.HTTPResponse.Status)
 }
 
 func awsServiceAndName(req *request.Request) (string, string) {

--- a/cloud-controller-manager/osc/oapi_provider.go
+++ b/cloud-controller-manager/osc/oapi_provider.go
@@ -106,7 +106,7 @@ func (p *awsSDKProvider) addAPILoggingHandlers(h *request.Handlers) {
 // controller retry loop)
 func (p *awsSDKProvider) getCrossRequestRetryDelay(regionName string) *CrossRequestRetryDelay {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getCrossRequestRetryDelay(%v)", regionName)
+	klog.V(5).Infof("getCrossRequestRetryDelay(%v)", regionName)
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -120,7 +120,7 @@ func (p *awsSDKProvider) getCrossRequestRetryDelay(regionName string) *CrossRequ
 
 func (p *awsSDKProvider) Compute(regionName string) (Compute, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("Compute(%v)", regionName)
+	klog.V(5).Infof("Compute(%v)", regionName)
 	// osc config
 	config := osc.NewConfiguration()
 	config.Debug = true
@@ -143,7 +143,7 @@ func (p *awsSDKProvider) Compute(regionName string) (Compute, error) {
 
 func (p *awsSDKProvider) LoadBalancing(regionName string) (LoadBalancer, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("LoadBalancing(%v)", regionName)
+	klog.V(5).Infof("LoadBalancing(%v)", regionName)
 	sess, err := NewSession(nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize AWS session: %v", err)
@@ -156,7 +156,7 @@ func (p *awsSDKProvider) LoadBalancing(regionName string) (LoadBalancer, error) 
 
 func (p *awsSDKProvider) Metadata() (EC2Metadata, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("Metadata()")
+	klog.V(5).Infof("Metadata()")
 	awsConfig := &aws.Config{
 		EndpointResolver: endpoints.ResolverFunc(SetupMetadataResolver()),
 	}

--- a/cloud-controller-manager/osc/oapi_vm.go
+++ b/cloud-controller-manager/osc/oapi_vm.go
@@ -50,6 +50,6 @@ type VM struct {
 // Gets the full information about this instance from the EC2 API
 func (i *VM) describeInstance() (*osc.Vm, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("describeInstance")
+	klog.V(5).Infof("describeInstance")
 	return describeInstance(i.compute, InstanceID(i.vmID))
 }

--- a/cloud-controller-manager/osc/osc_loadbalancer.go
+++ b/cloud-controller-manager/osc/osc_loadbalancer.go
@@ -64,7 +64,7 @@ var (
 // it as a map.
 func getLoadBalancerAdditionalTags(annotations map[string]string) map[string]string {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getLoadBalancerAdditionalTags(%v)", annotations)
+	klog.V(5).Infof("getLoadBalancerAdditionalTags(%v)", annotations)
 	additionalTags := make(map[string]string)
 	if additionalTagsList, ok := annotations[ServiceAnnotationLoadBalancerAdditionalTags]; ok {
 		additionalTagsList = strings.TrimSpace(additionalTagsList)
@@ -95,7 +95,7 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 	annotations map[string]string) (*elb.LoadBalancerDescription, error) {
 
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("ensureLoadBalancer(%v,%v,%v,%v,%v,%v,%v,%v,%v,)",
+	klog.V(5).Infof("ensureLoadBalancer(%v,%v,%v,%v,%v,%v,%v,%v,%v,)",
 		namespacedName, loadBalancerName, listeners, subnetIDs, securityGroupIDs,
 		internalELB, proxyProtocol, loadBalancerAttributes, annotations)
 
@@ -350,7 +350,7 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 //       listeners per elb is 100, this implementation is reduced from O(m*n) => O(n).
 func syncElbListeners(loadBalancerName string, listeners []*elb.Listener, listenerDescriptions []*elb.ListenerDescription) ([]*elb.Listener, []*int64, []*int64) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("syncElbListeners(%v,%v,%v)", loadBalancerName, listeners, listenerDescriptions)
+	klog.V(5).Infof("syncElbListeners(%v,%v,%v)", loadBalancerName, listeners, listenerDescriptions)
 	foundSet := make(map[int]bool)
 	removals := []*int64{}
 	removalsInstancePorts := []*int64{}
@@ -394,7 +394,7 @@ func syncElbListeners(loadBalancerName string, listeners []*elb.Listener, listen
 
 func elbListenersAreEqual(actual, expected *elb.Listener) bool {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("elbListenersAreEqual(%v,%v)", actual, expected)
+	klog.V(5).Infof("elbListenersAreEqual(%v,%v)", actual, expected)
 	if !elbProtocolsAreEqual(actual.Protocol, expected.Protocol) {
 		return false
 	}
@@ -417,7 +417,7 @@ func elbListenersAreEqual(actual, expected *elb.Listener) bool {
 // Comparison is case insensitive
 func elbProtocolsAreEqual(l, r *string) bool {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("elbProtocolsAreEqual(%v,%v)", l, r)
+	klog.V(5).Infof("elbProtocolsAreEqual(%v,%v)", l, r)
 	if l == nil || r == nil {
 		return l == r
 	}
@@ -428,7 +428,7 @@ func elbProtocolsAreEqual(l, r *string) bool {
 // Comparison is case insensitive
 func awsArnEquals(l, r *string) bool {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("awsArnEquals(%v,%v)", l, r)
+	klog.V(5).Infof("awsArnEquals(%v,%v)", l, r)
 	if l == nil || r == nil {
 		return l == r
 	}
@@ -439,7 +439,7 @@ func awsArnEquals(l, r *string) bool {
 // and using either sensible defaults or overrides via Service annotations
 func (c *Cloud) getExpectedHealthCheck(target string, annotations map[string]string) (*elb.HealthCheck, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getExpectedHealthCheck(%v,%v)", target, annotations)
+	klog.V(5).Infof("getExpectedHealthCheck(%v,%v)", target, annotations)
 	healthcheck := &elb.HealthCheck{Target: &target}
 	getOrDefault := func(annotation string, defaultValue int64) (*int64, error) {
 		i64 := defaultValue
@@ -479,7 +479,7 @@ func (c *Cloud) getExpectedHealthCheck(target string, annotations map[string]str
 func (c *Cloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerDescription,
 	protocol string, port int32, path string, annotations map[string]string) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("ensureLoadBalancerHealthCheck(%v,%v, %v, %v, %v)",
+	klog.V(5).Infof("ensureLoadBalancerHealthCheck(%v,%v, %v, %v, %v)",
 		loadBalancer, protocol, port, path, annotations)
 	name := aws.StringValue(loadBalancer.LoadBalancerName)
 
@@ -517,7 +517,7 @@ func (c *Cloud) ensureLoadBalancerInstances(loadBalancerName string,
 	lbInstances []*elb.Instance,
 	instanceIDs map[InstanceID]*osc.Vm) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("ensureLoadBalancerInstances(%v,%v, %v)", loadBalancerName, lbInstances, instanceIDs)
+	klog.V(5).Infof("ensureLoadBalancerInstances(%v,%v, %v)", loadBalancerName, lbInstances, instanceIDs)
 	expected := sets.NewString()
 	for id := range instanceIDs {
 		expected.Insert(string(id))
@@ -544,7 +544,7 @@ func (c *Cloud) ensureLoadBalancerInstances(loadBalancerName string,
 		removeInstance.InstanceId = aws.String(instanceID)
 		removeInstances = append(removeInstances, removeInstance)
 	}
-	klog.V(10).Infof("ensureLoadBalancerInstances register/Deregister addInstances(%v) , removeInstances(%v)", addInstances, removeInstances)
+	klog.V(5).Infof("ensureLoadBalancerInstances register/Deregister addInstances(%v) , removeInstances(%v)", addInstances, removeInstances)
 
 	if len(addInstances) > 0 {
 		registerRequest := &elb.RegisterInstancesWithLoadBalancerInput{}
@@ -573,7 +573,7 @@ func (c *Cloud) ensureLoadBalancerInstances(loadBalancerName string,
 
 func (c *Cloud) getLoadBalancerTLSPorts(loadBalancer *elb.LoadBalancerDescription) []int64 {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("getLoadBalancerTLSPorts(%v)", loadBalancer)
+	klog.V(5).Infof("getLoadBalancerTLSPorts(%v)", loadBalancer)
 	ports := []int64{}
 
 	for _, listenerDescription := range loadBalancer.ListenerDescriptions {
@@ -587,7 +587,7 @@ func (c *Cloud) getLoadBalancerTLSPorts(loadBalancer *elb.LoadBalancerDescriptio
 
 func (c *Cloud) ensureSSLNegotiationPolicy(loadBalancer *elb.LoadBalancerDescription, policyName string) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("ensureSSLNegotiationPolicy(%v,%v)", loadBalancer, policyName)
+	klog.V(5).Infof("ensureSSLNegotiationPolicy(%v,%v)", loadBalancer, policyName)
 	klog.V(2).Info("Describing load balancer policies on load balancer")
 	result, err := c.loadBalancer.DescribeLoadBalancerPolicies(&elb.DescribeLoadBalancerPoliciesInput{
 		LoadBalancerName: loadBalancer.LoadBalancerName,
@@ -631,7 +631,7 @@ func (c *Cloud) ensureSSLNegotiationPolicy(loadBalancer *elb.LoadBalancerDescrip
 
 func (c *Cloud) setSSLNegotiationPolicy(loadBalancerName, sslPolicyName string, port int64) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("setSSLNegotiationPolicy(%v,%v,%v)", loadBalancerName, sslPolicyName, port)
+	klog.V(5).Infof("setSSLNegotiationPolicy(%v,%v,%v)", loadBalancerName, sslPolicyName, port)
 	policyName := fmt.Sprintf(SSLNegotiationPolicyNameFormat, sslPolicyName)
 	request := &elb.SetLoadBalancerPoliciesOfListenerInput{
 		LoadBalancerName: aws.String(loadBalancerName),
@@ -650,7 +650,7 @@ func (c *Cloud) setSSLNegotiationPolicy(loadBalancerName, sslPolicyName string, 
 
 func (c *Cloud) createProxyProtocolPolicy(loadBalancerName string, update bool) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("createProxyProtocolPolicy(%v) updating(%v)",
+	klog.V(5).Infof("createProxyProtocolPolicy(%v) updating(%v)",
 		loadBalancerName, update)
 	request := &elb.CreateLoadBalancerPolicyInput{
 		LoadBalancerName: aws.String(loadBalancerName),
@@ -682,7 +682,7 @@ func (c *Cloud) createProxyProtocolPolicy(loadBalancerName string, update bool) 
 
 func (c *Cloud) setBackendPolicies(loadBalancerName string, instancePort int64, policies []*string) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("setBackendPolicies(%v,%v,%v)", loadBalancerName, instancePort, policies)
+	klog.V(5).Infof("setBackendPolicies(%v,%v,%v)", loadBalancerName, instancePort, policies)
 	request := &elb.SetLoadBalancerPoliciesForBackendServerInput{
 		InstancePort:     aws.Int64(instancePort),
 		LoadBalancerName: aws.String(loadBalancerName),
@@ -703,7 +703,7 @@ func (c *Cloud) setBackendPolicies(loadBalancerName string, instancePort int64, 
 
 func proxyProtocolEnabled(backend *elb.BackendServerDescription) bool {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("proxyProtocolEnabled(%v)", backend)
+	klog.V(5).Infof("proxyProtocolEnabled(%v)", backend)
 	for _, policy := range backend.PolicyNames {
 		if aws.StringValue(policy) == ProxyProtocolPolicyName {
 			return true
@@ -718,7 +718,7 @@ func proxyProtocolEnabled(backend *elb.BackendServerDescription) bool {
 // and we ignore instances which are not found
 func (c *Cloud) findInstancesForELB(nodes []*v1.Node) (map[InstanceID]*osc.Vm, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("findInstancesForELB(%v)", nodes)
+	klog.V(5).Infof("findInstancesForELB(%v)", nodes)
 
 	for _, node := range nodes {
 		if node.Spec.ProviderID == "" {

--- a/cloud-controller-manager/osc/tags.go
+++ b/cloud-controller-manager/osc/tags.go
@@ -70,7 +70,7 @@ type resourceTagging struct {
 
 func tagNameKubernetesCluster() string {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("tagNameKubernetesCluster()")
+	klog.V(5).Infof("tagNameKubernetesCluster()")
 	val, ok := os.LookupEnv("TAG_NAME_KUBERNETES_CLUSTER")
 	if !ok {
 		return TagNameKubernetesClusterLegacy
@@ -82,7 +82,7 @@ func tagNameKubernetesCluster() string {
 // If duplicate tags are found, returns an error
 func findClusterIDs(tags *[]osc.ResourceTag) (string, string, error) {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("findClusterIDs(%v)", tags)
+	klog.V(5).Infof("findClusterIDs(%v)", tags)
 	legacyClusterID := ""
 	newClusterID := ""
 
@@ -110,7 +110,7 @@ func findClusterIDs(tags *[]osc.ResourceTag) (string, string, error) {
 
 func (t *resourceTagging) init(legacyClusterID string, clusterID string) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("init(%v,%v)", legacyClusterID, clusterID)
+	klog.V(5).Infof("init(%v,%v)", legacyClusterID, clusterID)
 	if legacyClusterID != "" {
 		if clusterID != "" && legacyClusterID != clusterID {
 			return fmt.Errorf("clusterID tags did not match: %q vs %q", clusterID, legacyClusterID)
@@ -135,7 +135,7 @@ func (t *resourceTagging) init(legacyClusterID string, clusterID string) error {
 // If multiple (different) clusterIDs are found, returns an error
 func (t *resourceTagging) initFromTags(tags *[]osc.ResourceTag) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("initFromTags(%v)", tags)
+	klog.V(5).Infof("initFromTags(%v)", tags)
 	legacyClusterID, newClusterID, err := findClusterIDs(tags)
 	if err != nil {
 		return err
@@ -150,14 +150,14 @@ func (t *resourceTagging) initFromTags(tags *[]osc.ResourceTag) error {
 
 func (t *resourceTagging) clusterTagKey() string {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("clusterTagKey()")
+	klog.V(5).Infof("clusterTagKey()")
 	return TagNameKubernetesClusterPrefix + t.ClusterID
 }
 
 // To delete after last call to this function
 func (t *resourceTagging) hasClusterAWSTag(tags []*ec2.Tag) bool {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("hasClusterAWSTag(%v)", tags)
+	klog.V(5).Infof("hasClusterAWSTag(%v)", tags)
 	// if the clusterID is not configured -- we consider all instances.
 	if len(t.ClusterID) == 0 {
 		return true
@@ -173,7 +173,7 @@ func (t *resourceTagging) hasClusterAWSTag(tags []*ec2.Tag) bool {
 
 func (t *resourceTagging) hasClusterTag(tags *[]osc.ResourceTag) bool {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("hasClusterTag(%v)", tags)
+	klog.V(5).Infof("hasClusterTag(%v)", tags)
 	// if the clusterID is not configured -- we consider all instances.
 	if len(t.ClusterID) == 0 {
 		return true
@@ -192,7 +192,7 @@ func (t *resourceTagging) hasClusterTag(tags *[]osc.ResourceTag) bool {
 // and we add the tags.  If it has a different cluster's tags, that is an error.
 func (t *resourceTagging) readRepairClusterTags(client Compute, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string, observedTags *[]osc.ResourceTag) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("readRepairClusterTags(%v, %v, %v, %v, %v)",
+	klog.V(5).Infof("readRepairClusterTags(%v, %v, %v, %v, %v)",
 		client, resourceID, lifecycle, additionalTags, observedTags)
 	actualTagMap := make(map[string]string)
 	if observedTags == nil {
@@ -234,7 +234,7 @@ func (t *resourceTagging) readRepairClusterTags(client Compute, resourceID strin
 // The error code varies though (depending on what we are tagging), so we simply retry on all errors
 func (t *resourceTagging) createTags(client Compute, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string) error {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("createTags(%v,%v,%v,%v)", client, resourceID, lifecycle, additionalTags)
+	klog.V(5).Infof("createTags(%v,%v,%v,%v)", client, resourceID, lifecycle, additionalTags)
 
 	tags := t.buildTags(lifecycle, additionalTags)
 
@@ -286,7 +286,7 @@ func (t *resourceTagging) createTags(client Compute, resourceID string, lifecycl
 // This lets us run multiple k8s clusters in a single EC2 AZ
 func (t *resourceTagging) addFilters(filters []*ec2.Filter) []*ec2.Filter {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("addFilters(%v)", filters)
+	klog.V(5).Infof("addFilters(%v)", filters)
 	// if there are no clusterID configured - no filtering by special tag names
 	// should be applied to revert to legacy behaviour.
 	if len(t.ClusterID) == 0 {
@@ -309,7 +309,7 @@ func (t *resourceTagging) addFilters(filters []*ec2.Filter) []*ec2.Filter {
 // This lets us run multiple k8s clusters in a single EC2 AZ
 func (t *resourceTagging) addLegacyFilters(filters []*ec2.Filter) []*ec2.Filter {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("addLegacyFilters(%v)", filters)
+	klog.V(5).Infof("addLegacyFilters(%v)", filters)
 	// if there are no clusterID configured - no filtering by special tag names
 	// should be applied to revert to legacy behaviour.
 	if len(t.ClusterID) == 0 {
@@ -331,7 +331,7 @@ func (t *resourceTagging) addLegacyFilters(filters []*ec2.Filter) []*ec2.Filter 
 
 func (t *resourceTagging) buildTags(lifecycle ResourceLifecycle, additionalTags map[string]string) map[string]string {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("buildTags(%v,%v)", lifecycle, additionalTags)
+	klog.V(5).Infof("buildTags(%v,%v)", lifecycle, additionalTags)
 	tags := make(map[string]string)
 	for k, v := range additionalTags {
 		tags[k] = v
@@ -354,6 +354,6 @@ func (t *resourceTagging) buildTags(lifecycle ResourceLifecycle, additionalTags 
 
 func (t *resourceTagging) clusterID() string {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("clusterID()")
+	klog.V(5).Infof("clusterID()")
 	return t.ClusterID
 }

--- a/cloud-controller-manager/osc/utils.go
+++ b/cloud-controller-manager/osc/utils.go
@@ -99,7 +99,7 @@ func newEC2MetadataSvc() *ec2metadata.EC2Metadata {
 
 // NewMetadata create a new metadata service
 func NewMetadata() (MetadataService, error) {
-	klog.V(10).Infof("NewMetadata")
+	klog.V(5).Infof("NewMetadata")
 	svc := newEC2MetadataSvc()
 
 	metadata, err := NewMetadataService(svc)
@@ -398,7 +398,7 @@ func ipPermissionAWSExists(newPermission, existing *ec2.IpPermission, compareGro
 	}
 	// Check only if newPermission is a subset of existing. Usually it has zero or one elements.
 	// Not doing actual CIDR math yet; not clear it's needed, either.
-	klog.V(4).Infof("Comparing %v to %v", newPermission, existing)
+	klog.V(5).Infof("Comparing %v to %v", newPermission, existing)
 	if len(newPermission.IpRanges) > len(existing.IpRanges) {
 		return false
 	}
@@ -433,22 +433,22 @@ func ipPermissionAWSExists(newPermission, existing *ec2.IpPermission, compareGro
 }
 
 func ruleExists(newPermission *osc.SecurityGroupRule, existing *osc.SecurityGroupRule, compareGroupUserIDs bool) bool {
-	klog.V(4).Infof("ipPermissionExists(%v,%v,%v)", newPermission, existing, compareGroupUserIDs)
+	klog.V(5).Infof("ipPermissionExists(%v,%v,%v)", newPermission, existing, compareGroupUserIDs)
 	if newPermission.GetFromPortRange() != existing.GetFromPortRange() {
-		klog.V(4).Infof("Not the same FromPortRange %v != %v", newPermission.GetFromPortRange(), existing.GetFromPortRange())
+		klog.V(5).Infof("Not the same FromPortRange %v != %v", newPermission.GetFromPortRange(), existing.GetFromPortRange())
 		return false
 	}
 	if newPermission.GetToPortRange() != existing.GetToPortRange() {
-		klog.V(4).Infof("Not the same ToPortRange %v != %v", newPermission.GetToPortRange(), existing.GetToPortRange())
+		klog.V(5).Infof("Not the same ToPortRange %v != %v", newPermission.GetToPortRange(), existing.GetToPortRange())
 		return false
 	}
 	if newPermission.GetIpProtocol() != existing.GetIpProtocol() {
-		klog.V(4).Infof("Not the same IpProtocol %v != %v", newPermission.GetIpProtocol(), existing.GetIpProtocol())
+		klog.V(5).Infof("Not the same IpProtocol %v != %v", newPermission.GetIpProtocol(), existing.GetIpProtocol())
 		return false
 	}
 	// Check only if newPermission is a subset of existing. Usually it has zero or one elements.
 	// Not doing actual CIDR math yet; not clear it's needed, either.
-	klog.V(4).Infof("Comparing %v to %v", newPermission, existing)
+	klog.V(5).Infof("Comparing %v to %v", newPermission, existing)
 	if len(newPermission.GetIpRanges()) > len(existing.GetIpRanges()) {
 		return false
 	}
@@ -680,7 +680,7 @@ func updateConfigZone(cfg *CloudConfig, metadata EC2Metadata) error {
 
 func newAWSSDKProvider(creds *credentials.Credentials, cfg *CloudConfig) *awsSDKProvider {
 	debugPrintCallerFunctionName()
-	klog.V(10).Infof("newAWSSDKProvider(%v,%v)", creds, cfg)
+	klog.V(5).Infof("newAWSSDKProvider(%v,%v)", creds, cfg)
 	return &awsSDKProvider{
 		creds:          creds,
 		cfg:            cfg,
@@ -716,7 +716,7 @@ func debugGetFrame(skipFrames int) runtime.Frame {
 func debugPrintCallerFunctionName() {
 	called := debugGetFrame(1)
 	caller := debugGetFrame(2)
-	klog.V(10).Infof(
+	klog.V(5).Infof(
 		"DebugStack %s{"+
 			"\n\t call	 {\n\t\tFunc:%s, \n\t\tFile:(%s:%d)\n\t}"+
 			"\n\t called {\n\t\tFunc:%s, \n\t\tFile:(%s:%d)\n\t}"+

--- a/deploy/k8s-osc-ccm/templates/osc-ccm.yaml
+++ b/deploy/k8s-osc-ccm/templates/osc-ccm.yaml
@@ -144,7 +144,7 @@ spec:
             - /bin/osc-cloud-controller-manager
             - --configure-cloud-routes=false
             - --cloud-provider=osc
-            - -v=10
+            - -v={{ .Values.verbose }}
             - --logtostderr
           env:
             - name: OSC_ACCOUNT_ID

--- a/deploy/k8s-osc-ccm/values.yaml
+++ b/deploy/k8s-osc-ccm/values.yaml
@@ -9,7 +9,7 @@ image:
   tag: v0.0.10beta
   pullPolicy: IfNotPresent
 
-verbose: ""
+verbose: 5
 oscSecretName: ""
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/osc-ccm-manifest.yml
+++ b/deploy/osc-ccm-manifest.yml
@@ -146,7 +146,7 @@ spec:
             - /bin/osc-cloud-controller-manager
             - --configure-cloud-routes=false
             - --cloud-provider=osc
-            - -v=10
+            - -v=5
             - --logtostderr
           env:
             - name: OSC_ACCOUNT_ID


### PR DESCRIPTION
Logs was flooded with leader election requests. Reading through this [logging convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md). We have adjusted log level of some logs and the default log level is set to `TRACE (5)` .

Leader election request body traces are set to level `8` (https://github.com/kubernetes/client-go/blob/46d4284b93f0f2fdf846e2593d05c8094689fabc/rest/request.go#L1126)

Closes https://github.com/outscale-dev/cloud-provider-osc/issues/64