### PR TITLE
Ignore CVE-2022-32149

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,3 +2,5 @@
 CVE-2022-1996
 # https://github.com/advisories/GHSA-69cg-p879-7622
 CVE-2022-27664
+# https://avd.aquasec.com/nvd/cve-2022-32149
+CVE-2022-32149 


### PR DESCRIPTION
-> need to upgrade k8s libraries

cf (https://github.com/outscale-dev/osc-bsu-csi-driver/pull/417)