### PR TITLE
Set the version of helm to use in e2e

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -31,7 +31,9 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
     - uses: azure/setup-kubectl@v2.0
-    - uses: azure/setup-helm@v1
+    - uses: azure/setup-helm@v3
+      with:
+        version: v3.10.1
     - uses: actions/setup-python@v2
     - uses: outscale-dev/frieza-github-actions/frieza-clean@master
       with:


### PR DESCRIPTION
The first version of `setup-helm` does not retrieve the latest version of `helm`.

