### PR TITLE
Handle multiple AZ

### DIFF
--- a/cloud-controller-manager/osc/ccm_const.go
+++ b/cloud-controller-manager/osc/ccm_const.go
@@ -161,6 +161,10 @@ const ServiceAnnotationLoadBalancerNameLength = "service.beta.kubernetes.io/osc-
 // service to specify, the load balancer name max length is 32 else it will be truncated.
 const ServiceAnnotationLoadBalancerName = "service.beta.kubernetes.io/osc-load-balancer-name"
 
+// ServiceAnnotationLoadBalancerSubnetID is the annotation used on the
+// service to specify, the subnet in which to create the load balancer.
+const ServiceAnnotationLoadBalancerSubnetID = "service.beta.kubernetes.io/osc-load-balancer-subnet-id"
+
 // LbNameMaxLength the load balancer name max length value.
 const LbNameMaxLength = int64(32)
 

--- a/cloud-controller-manager/osc/osc_fakes.go
+++ b/cloud-controller-manager/osc/osc_fakes.go
@@ -77,15 +77,15 @@ func NewFakeAWSServices(clusterID string) *FakeOscServices {
 		SecurityGroupId: aws.String("sg-1234"),
 		Tags: &[]osc.ResourceTag{
 			{
-				Key: fmt.Sprintf("%v%v", TagNameKubernetesClusterPrefix, clusterID),
+				Key:   fmt.Sprintf("%v%v", TagNameKubernetesClusterPrefix, clusterID),
 				Value: "owned",
 			},
 			{
-				Key: fmt.Sprintf("%v%v", TagNameMainSG, clusterID),
+				Key:   fmt.Sprintf("%v%v", TagNameMainSG, clusterID),
 				Value: "true",
 			},
 		},
-		InboundRules: &[]osc.SecurityGroupRule{},
+		InboundRules:  &[]osc.SecurityGroupRule{},
 		OutboundRules: &[]osc.SecurityGroupRule{},
 	}
 
@@ -132,7 +132,7 @@ type FakeComputeImpl struct {
 	DescribeSubnetsInput     *osc.ReadSubnetsRequest
 	RouteTables              []osc.RouteTable
 	DescribeRouteTablesInput *osc.ReadRouteTablesRequest
-	MainSecurityGroup			*osc.SecurityGroup
+	MainSecurityGroup        *osc.SecurityGroup
 }
 
 // ReadVms returns fake instance descriptions
@@ -243,9 +243,9 @@ func (ec2i *FakeComputeImpl) CreateSecurityGroupRule(request *osc.CreateSecurity
 
 	rule := osc.SecurityGroupRule{
 		FromPortRange: request.FromPortRange,
-		IpProtocol: request.IpProtocol,
-		IpRanges: &[]string{request.GetIpRange()},
-		ToPortRange: request.ToPortRange, 
+		IpProtocol:    request.IpProtocol,
+		IpRanges:      &[]string{request.GetIpRange()},
+		ToPortRange:   request.ToPortRange,
 	}
 
 	if flow == "Inbound" {
@@ -491,20 +491,19 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 
 // FakeELB is a fake ELB client used for testing
 type FakeELB struct {
-	aws *FakeOscServices
+	aws           *FakeOscServices
 	LoadBalancers map[string]*elb.LoadBalancerDescription
 }
 
 // CreateLoadBalancer is not implemented but is required for interface
 // conformance
 func (fakeElb *FakeELB) CreateLoadBalancer(input *elb.CreateLoadBalancerInput) (*elb.CreateLoadBalancerOutput, error) {
-	lb := elb.LoadBalancerDescription {
-		Subnets: input.Subnets,
+	lb := elb.LoadBalancerDescription{
+		Subnets:           input.Subnets,
 		AvailabilityZones: input.AvailabilityZones,
-		DNSName: aws.String(fmt.Sprintf("%v", *input.LoadBalancerName)),
-		HealthCheck: &elb.HealthCheck{},
-		LoadBalancerName: input.LoadBalancerName,
-		
+		DNSName:           aws.String(fmt.Sprintf("%v", *input.LoadBalancerName)),
+		HealthCheck:       &elb.HealthCheck{},
+		LoadBalancerName:  input.LoadBalancerName,
 	}
 
 	if fakeElb.LoadBalancers == nil {
@@ -630,11 +629,11 @@ func (fakeElb *FakeELB) DescribeLoadBalancerPolicies(input *elb.DescribeLoadBala
 // interface conformance
 func (fakeElb *FakeELB) DescribeLoadBalancerAttributes(input *elb.DescribeLoadBalancerAttributesInput) (*elb.DescribeLoadBalancerAttributesOutput, error) {
 	return &elb.DescribeLoadBalancerAttributesOutput{
-				LoadBalancerAttributes: &elb.LoadBalancerAttributes{
-					ConnectionDraining: &elb.ConnectionDraining{Enabled: aws.Bool(false)},
-					ConnectionSettings: &elb.ConnectionSettings{IdleTimeout: aws.Int64(60)},
-				},
-			}, nil
+		LoadBalancerAttributes: &elb.LoadBalancerAttributes{
+			ConnectionDraining: &elb.ConnectionDraining{Enabled: aws.Bool(false)},
+			ConnectionSettings: &elb.ConnectionSettings{IdleTimeout: aws.Int64(60)},
+		},
+	}, nil
 }
 
 // ModifyLoadBalancerAttributes is not implemented but is required for

--- a/cloud-controller-manager/osc/osc_loadbalancer.go
+++ b/cloud-controller-manager/osc/osc_loadbalancer.go
@@ -317,7 +317,7 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 			return nil, err
 		}
 
-		foundAttributes := &describeAttributesOutput.LoadBalancerAttributes
+		foundAttributes := describeAttributesOutput.LoadBalancerAttributes
 
 		// Update attributes if they're dirty
 		if !reflect.DeepEqual(loadBalancerAttributes, foundAttributes) {

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -27,4 +27,5 @@ The Service for load balancer type supported annotation are :
 | service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval | the annotation used on the service to specify, in seconds, the interval between health checks. |
 | service.beta.kubernetes.io/osc-load-balancer-name-length | the annotation used on the service to specify, the load balancer name length max value is 32. |
 | service.beta.kubernetes.io/osc-load-balancer-name | the annotation used on the service to specify, the load balancer name max length is 32 else it will be truncated. |
+| service.beta.kubernetes.io/osc-load-balancer-subnet-id | the annotation used on the service to specify, the subnet in which to create the load balancer |
 


### PR DESCRIPTION
The solution implemented is the following:
- if multiple subnets in different AZ is detected and no user request: take the first lexicography subnet
- if multiple subnets in different AZ is detected and user request through the annotation`service.beta.kubernetes.io/osc-load-balancer-subnet-id`: use the user subnet

Closes #156 

